### PR TITLE
Restructure block data section (and add additional info)

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,62 +249,64 @@ If you place the Proxmark in between the AMS reader and the spool, make sure tha
          ```
          [+] saved 1024 bytes to binary file /Users/mitch/hf-mf-75066B1D-dump.bin
          ```
-
-
 ## Tag Documentation
-This contains documentation for the known and unknown data that is contained in each block on the RFID tag.
-### Block Overview
-Summary of what kind of data is stored in each block. Detailed info for each block is documented below.
-| sec | blk | Data                                                                                   |
-|-----|-----|----------------------------------------------------------------------------------------|
-|  0  |  0  | [Block 0](#block-0) UID and Tag Manufacturer Data                                      |
-|  0  |  1  | [Block 1](#block-1) Tray Info Index                                                    |
-|  0  |  2  | [Block 2](#block-2) Filament Type                                                      |
-|  0  |  3  | [Block 3](#mifare-encryption-keys) MIFARE encryption keys, Unrelated to BambuLab       |
-|  1  |  0  | [Block 4](#block-4) Detailed Filament Type                                             |
-|  1  |  1  | [Block 5](#block-5) Spool Weight, Color Code                                           |
-|  1  |  2  | [Block 6](#block-6) Min/Max Hotend, Bed Temp, Bed Temp Type, Drying Time, Drying Temp  |
-|  1  |  3  | [Block 7](#mifare-encryption-keys) MIFARE encryption keys, Unrelated to BambuLab       |
-|  2  |  0  | [Block 8](#block-8) X Cam Info                                                         |
-|  2  |  1  | [Block 9](#block-9) Tray UID                                                           |
-|  2  |  2  | [Block 10](#block-10) **Unknown**                                                      |
-|  2  |  3  | [Block 11](#mifare-encryption-keys) MIFARE encryption keys, Unrelated to BambuLab      |
-|  3  |  0  | [Block 12](#block-12) Production Date/Time                                             |
-|  3  |  1  | [Block 13](#block-13) **Unknown**                                                      |
-|  3  |  2  | [Block 14](#block-14) **Unknown**                                                      |
-|  3  |  3  | [Block 15](#mifare-encryption-keys) MIFARE encryption keys, Unrelated to BambuLab      |
-|  4  |  0  | **Empty**                                                                              |
-|  4  |  1  | **Empty**                                                                              |
-|  4  |  2  | **Empty**                                                                              |
-|  4  |  3  | [Block 19](#mifare-encryption-keys) MIFARE encryption keys, Unrelated to BambuLab      |
-|  5  |  0  | **Empty**                                                                              |
-|  5  |  1  | **Empty**                                                                              |
-|  5  |  2  | **Empty**                                                                              |
-|  5  |  3  | [Block 23](#mifare-encryption-keys) MIFARE encryption keys, Unrelated to BambuLab      |
-|  6  |  0  | **Empty**                                                                              |
-|  6  |  1  | **Empty**                                                                              |
-|  6  |  2  | **Empty**                                                                              |
-|  6  |  3  | [Block 27](#mifare-encryption-keys) MIFARE encryption keys, Unrelated to BambuLab      |
-|  7  |  0  | **Empty**                                                                              |
-|  7  |  1  | **Empty**                                                                              |
-|  7  |  2  | **Empty**                                                                              |
-|  7  |  3  | [Block 31](#mifare-encryption-keys) MIFARE encryption keys, Unrelated to BambuLab      |
-|  8  |  0  | **Empty**                                                                              |
-|  8  |  1  | **Empty**                                                                              |
-|  8  |  2  | **Empty**                                                                              |
-|  8  |  3  | [Block 35](#mifare-encryption-keys) MIFARE encryption keys, Unrelated to BambuLab      |
-|  9  |  0  | **Empty**                                                                              |
-|  9  |  1  | **Empty**                                                                              |
-|  9  |  2  | **Empty**                                                                              |
-|  9  |  3  | [Block 39](#mifare-encryption-keys) MIFARE encryption keys, Unrelated to BambuLab      |
-| 10-15 | *  | **RSA-2048 Signature**                                                                |
 
+This contains documentation for the known and unknown data that is contained in each block on the RFID tag.
+
+### Block Overview
+
+Summary of what kind of data is stored in each block. Detailed info for each block is documented below.
+| sec | blk | Data |
+|-----|-----|----------------------------------------------------------------------------------------|
+| 0 | 0 | [Block 0](#block-0) UID and Tag Manufacturer Data |
+| 0 | 1 | [Block 1](#block-1) Tray Info Index |
+| 0 | 2 | [Block 2](#block-2) Filament Type |
+| 0 | 3 | [Block 3](#mifare-encryption-keys) MIFARE encryption keys, Unrelated to BambuLab |
+| 1 | 0 | [Block 4](#block-4) Detailed Filament Type |
+| 1 | 1 | [Block 5](#block-5) Spool Weight, Color Code |
+| 1 | 2 | [Block 6](#block-6) Min/Max Hotend, Bed Temp, Bed Temp Type, Drying Time, Drying Temp |
+| 1 | 3 | [Block 7](#mifare-encryption-keys) MIFARE encryption keys, Unrelated to BambuLab |
+| 2 | 0 | [Block 8](#block-8) X Cam Info |
+| 2 | 1 | [Block 9](#block-9) Tray UID |
+| 2 | 2 | [Block 10](#block-10) **Unknown** |
+| 2 | 3 | [Block 11](#mifare-encryption-keys) MIFARE encryption keys, Unrelated to BambuLab |
+| 3 | 0 | [Block 12](#block-12) Production Date/Time |
+| 3 | 1 | [Block 13](#block-13) **Unknown** |
+| 3 | 2 | [Block 14](#block-14) **Unknown** |
+| 3 | 3 | [Block 15](#mifare-encryption-keys) MIFARE encryption keys, Unrelated to BambuLab |
+| 4 | 0 | **Empty** |
+| 4 | 1 | **Empty** |
+| 4 | 2 | **Empty** |
+| 4 | 3 | [Block 19](#mifare-encryption-keys) MIFARE encryption keys, Unrelated to BambuLab |
+| 5 | 0 | **Empty** |
+| 5 | 1 | **Empty** |
+| 5 | 2 | **Empty** |
+| 5 | 3 | [Block 23](#mifare-encryption-keys) MIFARE encryption keys, Unrelated to BambuLab |
+| 6 | 0 | **Empty** |
+| 6 | 1 | **Empty** |
+| 6 | 2 | **Empty** |
+| 6 | 3 | [Block 27](#mifare-encryption-keys) MIFARE encryption keys, Unrelated to BambuLab |
+| 7 | 0 | **Empty** |
+| 7 | 1 | **Empty** |
+| 7 | 2 | **Empty** |
+| 7 | 3 | [Block 31](#mifare-encryption-keys) MIFARE encryption keys, Unrelated to BambuLab |
+| 8 | 0 | **Empty** |
+| 8 | 1 | **Empty** |
+| 8 | 2 | **Empty** |
+| 8 | 3 | [Block 35](#mifare-encryption-keys) MIFARE encryption keys, Unrelated to BambuLab |
+| 9 | 0 | **Empty** |
+| 9 | 1 | **Empty** |
+| 9 | 2 | **Empty** |
+| 9 | 3 | [Block 39](#mifare-encryption-keys) MIFARE encryption keys, Unrelated to BambuLab |
+| 10-15 | \* | **RSA-2048 Signature** |
 
 The first part of the filament serial number seems to be the Tag UID.
 
-LE = Little Endian
+> [!NOTE]
+> All numbers are encoded as Little Endian (LE).
 
 ### MIFARE Encryption Keys
+
 Every 4th block (eg Sector X, Block 3) contains encryption keys that are part of the MIFARE RFID standard.
 This has nothing to do with BambuLab's memory format.
 All BambuLab tags use the same Permission Bits (Access Control)
@@ -312,11 +314,11 @@ All BambuLab tags use the same Permission Bits (Access Control)
 Example Data:
 `AA AA AA AA AA AA PP PP PP PP BB BB BB BB BB BB`
 
-| bytes   | type     |  example data location   | Description                                   |
-|---------|----------|--------------------------|-----------------------------------------------|
-|  5-0    | RAW Bin  | AA AA AA AA AA AA        | A-Key                                         |
-|  9-6    | RAW Bin  | PP PP PP PP              | Permission Bits (Access Control)<br>ALWAYS `87 87  87 69` (hex) for Bambu Tags |
-|  15-10  | RAW Bin  | BB BB BB BB BB BB        | B-Key (always `00 00 00 00 00 00` for Bambu tags) |
+| position | length | type    | Description                                                                    |
+| -------- | ------ | ------- | ------------------------------------------------------------------------------ |
+| 0 (AA)   | 6      | RAW Bin | A-Key                                                                          |
+| 6 (PP)   | 4      | RAW Bin | Permission Bits (Access Control)<br>ALWAYS `87 87  87 69` (hex) for Bambu Tags |
+| 10 (BB)  | 6      | RAW Bin | B-Key (always `00 00 00 00 00 00` for Bambu tags)                              |
 
 ### Block 0
 
@@ -325,125 +327,126 @@ Note: Block 0 is Read-only. The contents are set by the tag manufacturer.
 Example Data:
 `AA AA AA AA BB BB BB BB BB BB BB BB BB BB BB BB`
 
-| bytes | type     |  example data location              | Description                                   |
-|-------|----------|-------------------------------------|-----------------------------------------------|
-|  7-0  | string   | AA AA AA AA                         | Tag UID                                       |
-| 15-8  |  string  | BB BB BB BB BB BB BB BB BB BB BB BB | Tag Manufacturer Data (Bin)                   |
+| position | length | type    | Description           |
+| -------- | ------ | ------- | --------------------- |
+| 0 (AA)   | 4      | string  | Tag UID               |
+| 4 (BB)   | 12     | RAW Bin | Tag Manufacturer Data |
 
 ### Block 1
 
 Example Data:
 `AA AA AA AA AA AA AA AA BB BB BB BB BB BB BB BB`
 
-| bytes | type     |  example data location   | Description                                   |
-|-------|----------|--------------------------|-----------------------------------------------|
-|  7-0  | string   | BB BB BB BB BB BB BB BB  | Tray Info Index - Unique Material Identifier  |
-| 15-8  |  string  | AA AA AA AA AA AA AA AA  | **Unkown**                                    |
+| position | length | type   | Description                                   |
+| -------- | ------ | ------ | --------------------------------------------- |
+| 0 (AA)   | 8      | string | Tray Info Index - Material Variant Identifier |
+| 8 (BB)   | 16     | string | Tray Info Index - Unique Material Identifier  |
 
 ### Block 2
 
 Example Data:
 `AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA`
 
-| bytes | type     |  example data location                          | Description                       |
-|-------|----------|-------------------------------------------------|-----------------------------------|
-|  15-0  | string  | AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA | Filament type                     |
-
+| position | length | type   | Description   |
+| -------- | ------ | ------ | ------------- |
+| 0 (AA)   | 16     | string | Filament Type |
 
 ### Block 4
 
 Example Data:
 `AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA`
 
-| bytes | type     |  example data location                          |description                      |
-|-------|----------|-------------------------------------------------|---------------------------------|
-|  15-0  | string  | AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA | detailed Filament type          |
+| position | length | type   | description            |
+| -------- | ------ | ------ | ---------------------- |
+| 0 (AA)   | 16     | string | Detailed Filament Type |
 
 Known Values:
+
 - PLA Basic
+- PLA Tough
+- Support for PLA
+- PLA-CF
+- PETG Basic
 
 ### Block 5
 
 Example Data:
-`AA AA AA AA BB BB CC CC CC CC CC CC CC CC CC CC`
+`AA AA AA AA BB BB __ __ CC CC CC CC __ __ __ __`
 
-| bytes | type                 |  example data location         | Description                             |
-|-------|----------------|--------------------------------|-----------------------------------------------|
-|  9-0 | **Unkown**      | CC CC CC CC CC CC CC CC CC CC  | **Unkown**                                    |
-| 11-10  |  uint16 (LE)  | BB BB                          | Spool Weight in g  HEX: E803 --> 1000 g       |
-| 15-12  |  RGBA in HEX  | AA AA AA AA                    | Color in hex RBGA                             |
+| position | length | type        | Description                                  |
+| -------- | ------ | ----------- | -------------------------------------------- |
+| 0 (AA)   | 4      | RGBA        | Color in hex RBGA                            |
+| 4 (BB)   | 2      | uint16 (LE) | Spool Weight in grams (`E8 03` --> 1000 g)   |
+| 8 (CC)   | 8      | float (LE)  | Filament Diameter in milimeters              |
 
 ### Block 6
 
 Example Data:
-`AA AA BB BB CC CC DD DD EE EE FF FF GG GG GG GG`
+`AA AA BB BB CC CC DD DD EE EE FF FF __ __ __ __`
 
-| bytes | type          |  example data location   | Description                             |
-|-------|---------------|--------------------------|-----------------------------------------------|
-|  3-0  | **Unused?**   | GG GG GG GG              | **Unkown**                                    |
-|  5-4  | uint16 (LE)   | FF FF                    | Min- or Maxtemperature for Hotend             |
-|  7-6  | uint16 (LE)   | EE EE                    | Min- or Maxtemperature for Hotend             |
-|  9-8  | uint16 (LE)   | DD DD                    | Bed Temperatur in °C                          |
-| 11-10 | uint16 (LE)   | CC CC                    | Bed Temerature Type                           |
-| 13-12 | uint16 (LE)   | BB BB                    | Drying time in h                              |
-| 15-14 | uint16 (LE)   | AA AA                    | Drying temp in °C                             |
-
+| position | length | type        | Description                       |
+| -------- | ------ | ----------- | --------------------------------- |
+| 0 (AA)   | 2      | uint16 (LE) | Drying temp in °C                 |
+| 2 (BB)   | 2      | uint16 (LE) | Drying time in h                  |
+| 4 (CC)   | 4      | uint16 (LE) | Bed Temerature Type               |
+| 6 (DD)   | 2      | uint16 (LE) | Bed Temperatur in °C              |
+| 8 (EE)   | 2      | uint16 (LE) | Min- or Maxtemperature for Hotend |
+| 10 (FF)  | 2      | uint16 (LE) | Min- or Maxtemperature for Hotend |
 
 ### Block 8
 
 Example Data:
 `AA AA AA AA AA AA AA AA AA AA AA AA BB BB BB BB`
 
-| bytes | type       |  example data location              |description                      |
-|-------|------------|-------------------------------------|---------------------------------|
-|  3-0  | **Unkown** | BB BB BB BB                         | **Unkown**                      |
-| 15-4  | RAW Bin    | AA AA AA AA AA AA AA AA AA AA AA AA | X Cam info                      |
+| position | length | type       | description             |
+| -------- | ------ | ---------- | ----------------------- |
+| 0 (AA)   | 12     | RAW Bin    | X Cam info              |
+| 12 (BB)  | 4      | float (LE) | **Nozzle Diameter...?** |
 
 ### Block 9
 
 Example Data:
 `AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA`
 
-| bytes | type     |  example data location                          | Description                       |
-|-------|----------|-------------------------------------------------|-----------------------------------|
-| 15-0  | UID      | AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA | TrayUID                           |
+| position | length | type   | Description |
+| -------- | ------ | ------ | ----------- |
+| 0 (AA)   | 16     | string | Tray UID    |
 
 ### Block 10
 
 Example Data:
-`AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA`
+`__ __ __ __ AA AA __ __ __ __ __ __ __ __ __ __`
 
-| bytes | type     |  example data location                          | Description                       |
-|-------|----------|-------------------------------------------------|-----------------------------------|
-| 15-0  | Unknown  | AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA | **Unknown** (binary data)             |
+| position | length | type    | Description               |
+| -------- | ------ | ------- | ------------------------- |
+| 4 (AA)   | 2      | uint16 (LE) | Spool Width in µm (`E1 19` --> 6625µm --> 66.25mm ) |
 
 ### Block 12
 
 Example Data:
 `AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA`
 
-| bytes | type     |  example data location                          | Description                       |
-|-------|----------|-------------------------------------------------|----------------------------------------|
-| 15-0  | string   | AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA | Production Date and Time in ASCII ?  `<year>_<month>_<day>_<hour>_<minute>`                           |
+| position | length | type   | Description                                                                |
+| -------- | ------ | ------ | -------------------------------------------------------------------------- |
+| 0 (AA)   | 16     | string | Production Date and Time in ASCII (`<year>_<month>_<day>_<hour>_<minute>`) |
 
 ### Block 13
 
 Example Data:
 `AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA`
 
-| bytes | type     |  example data location                          | Description                       |
-|-------|----------|-------------------------------------------------|-----------------------------------|
-| 15-0  | Unknown  | AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA | **Unknown** (ASCII data)             |
+| position | length | type   | Description                        |
+| -------- | ------ | ------ | ---------------------------------- |
+| 0 (AA)   | 16     | string | **Short Production Date/Time...?** |
 
 ### Block 14
 
 Example Data:
-`AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA`
+`__ __ __ __ AA AA __ __ __ __ __ __ __ __ __ __`
 
-| bytes | type     |  example data location                          | Description                       |
-|-------|----------|-------------------------------------------------|-----------------------------------|
-| 15-0  | Unknown  | AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA AA | **Unknown** (binary data)             |
-
+| position | length | type        | Description                       |
+| -------- | ------ | ----------- | --------------------------------- |
+| 4 (AA)   | 2      | uint16 (LE) | **Filament length in meters...?** |
 
 ## Compatible RFID tags -  By generation
 


### PR DESCRIPTION
This PR performs two changes to the section about the block data:

- Restructures the tables to be a little more readable
  - Replaces the "bytes" and "example data location" columns with "position" and "length"
  - Sorts the rows in position order
  - Marks all unused bytes with underscores in the example data
- Adds additional data
  - Lists additional known values for "Detailed Filament Type"
  - Updates unknown data with some suggestions listed in #9

Fixes #9.